### PR TITLE
sort_By -> sort_by

### DIFF
--- a/Source/Parameters+CDYelpFusionKit.swift
+++ b/Source/Parameters+CDYelpFusionKit.swift
@@ -84,7 +84,7 @@ extension Dictionary where Key: ExpressibleByStringLiteral, Value: Any {
         }
         if let sortBy = sortBy,
             sortBy.rawValue != "" {
-            params["sort_By"] = sortBy.rawValue
+            params["sort_by"] = sortBy.rawValue
         }
         if let priceTiers = priceTiers,
             priceTiers.count > 0 {


### PR DESCRIPTION
This fixes a bug since Yelp Fusion is case sensitive.

### Issue Link :link:
> What issue does this fix? If an issue doesn't exist, remove this section.

Yelp Fusion is case sensitive and right now sort_by is being improperly passed and therefore ignored in results since it is being passed as sort_By instead of sort_by.

### Goals :soccer:
> List the high-level objectives of this pull request.
> Include any relevant context.

Fix the capitalization bug.

