### PR TITLE
Update UIImage+CDYelpFusionKit.swift

### DIFF
--- a/Source/UIImage+CDYelpFusionKit.swift
+++ b/Source/UIImage+CDYelpFusionKit.swift
@@ -36,7 +36,7 @@ public extension CDImage {
         return CDImage(named: name)
 #else
         let bundle = Bundle(identifier: CDYelpFusionKitBundleIdentifier)
-        return bundle?.image(forResource: name)
+        return bundle?.image(forResource: NSImage.Name(rawValue: name!))
 #endif
     }
     


### PR DESCRIPTION
fix bug on macOS

### Issue Link :link:
> What issue does this fix? If an issue doesn't exist, remove this section.

This fixes an error when building with a target that is macOS.

### Testing Details :mag:
> Describe what tests you've added for your changes.

Try building in Xcode 9.2 without this on a project targeting macOS using CDYelpFusionKit as a CocoaPod.