### PR TITLE
Bug fix/swift package manager invalid manifest

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -42,7 +42,7 @@ let package = Package(
             targets: ["CDYelpFusionKit"])
     ],
     dependencies: [
-        .package(url: "https://github.com/Alamofire/Alamofire.git", "5.2.2")
+        .package(url: "https://github.com/Alamofire/Alamofire.git", .upToNextMajor(from: "5.2.2"))
     ],
     targets: [
         .target(

--- a/Package.swift
+++ b/Package.swift
@@ -48,5 +48,6 @@ let package = Package(
         .target(
             name: "CDYelpFusionKit",
             path: "Source")
+            linkerSettings: [.linkedFramework("Alamofire", .when(platforms: [.iOS])
     ],
     swiftLanguageVersions: [.v5])

--- a/Package.swift
+++ b/Package.swift
@@ -48,8 +48,9 @@ let package = Package(
     targets: [
         .target(
             name: "CDYelpFusionKit",
+            path: "Source",
             dependencies: [.product(name: "Alamofire", package: "Alamofire")],
-            path: "Source"),
-            linkerSettings: [.linkedFramework("UIKit", .when(platforms: [.iOS, .tvOS])])
+            linkerSettings: [.linkedFramework("UIKit", .when(platforms: [.iOS, .tvOS])]
+        ),
     ],
     swiftLanguageVersions: [.v5])

--- a/Package.swift
+++ b/Package.swift
@@ -42,11 +42,14 @@ let package = Package(
             targets: ["CDYelpFusionKit"])
     ],
     dependencies: [
-        .package(url: "https://github.com/Alamofire/Alamofire.git", .upToNextMajor(from: "5.4.3"))
+        .package(name: "Alamofire", 
+                 url: "https://github.com/Alamofire/Alamofire.git", 
+                 .upToNextMajor(from: "5.4.3"))
     ],
     targets: [
         .target(
             name: "CDYelpFusionKit",
-            path: "Source")
+            path: "Source"),
+            dependencies: [ .product(name: "Alamofire", package: "Alamofire"),]
     ],
     swiftLanguageVersions: [.v5])

--- a/Package.swift
+++ b/Package.swift
@@ -42,7 +42,7 @@ let package = Package(
             targets: ["CDYelpFusionKit"])
     ],
     dependencies: [
-        .package(url: "https://github.com/Alamofire/Alamofire.git", .upToNextMajor(from: "5.2.2"))
+        .package(url: "https://github.com/Alamofire/Alamofire.git", .upToNextMajor(from: "5.4.3"))
     ],
     targets: [
         .target(

--- a/Package.swift
+++ b/Package.swift
@@ -42,8 +42,7 @@ let package = Package(
             targets: ["CDYelpFusionKit"])
     ],
     dependencies: [
-        .package(name: "Alamofire", 
-                 url: "https://github.com/Alamofire/Alamofire.git", 
+        .package(url: "https://github.com/Alamofire/Alamofire.git", 
                  .upToNextMajor(from: "5.4.3"))
     ],
     targets: [

--- a/Package.swift
+++ b/Package.swift
@@ -47,7 +47,7 @@ let package = Package(
     targets: [
         .target(
             name: "CDYelpFusionKit",
-            path: "Source")
+            path: "Source"),
             linkerSettings: [.linkedFramework("Alamofire", .when(platforms: [.iOS])
     ],
     swiftLanguageVersions: [.v5])

--- a/Package.swift
+++ b/Package.swift
@@ -49,6 +49,7 @@ let package = Package(
         .target(
             name: "CDYelpFusionKit",
             dependencies: [.product(name: "Alamofire", package: "Alamofire")],
-            path: "Source")
+            path: "Source"),
+            linkerSettings: [.linkedFramework("UIKit", .when(platforms: [.iOS, .tvOS]))
     ],
     swiftLanguageVersions: [.v5])

--- a/Package.swift
+++ b/Package.swift
@@ -49,7 +49,7 @@ let package = Package(
     targets: [
         .target(
             name: "CDYelpFusionKit",
+            dependencies: .product(name: "Alamofire", package: "Alamofire"),
             path: "Source"),
-            dependencies: [ .product(name: "Alamofire", package: "Alamofire"),]
     ],
     swiftLanguageVersions: [.v5])

--- a/Package.swift
+++ b/Package.swift
@@ -50,6 +50,6 @@ let package = Package(
             name: "CDYelpFusionKit",
             dependencies: [.product(name: "Alamofire", package: "Alamofire")],
             path: "Source"),
-            linkerSettings: [.linkedFramework("UIKit", .when(platforms: [.iOS, .tvOS]))
+            linkerSettings: [.linkedFramework("UIKit", .when(platforms: [.iOS, .tvOS])])
     ],
     swiftLanguageVersions: [.v5])

--- a/Package.swift
+++ b/Package.swift
@@ -49,7 +49,7 @@ let package = Package(
     targets: [
         .target(
             name: "CDYelpFusionKit",
-            dependencies: .product(name: "Alamofire", package: "Alamofire"),
-            path: "Source"),
+            dependencies: [.product(name: "Alamofire", package: "Alamofire")],
+            path: "Source")
     ],
     swiftLanguageVersions: [.v5])

--- a/Package.swift
+++ b/Package.swift
@@ -47,7 +47,6 @@ let package = Package(
     targets: [
         .target(
             name: "CDYelpFusionKit",
-            path: "Source"),
-            linkerSettings: [.linkedFramework("Alamofire", .when(platforms: [.iOS])
+            path: "Source")
     ],
     swiftLanguageVersions: [.v5])

--- a/Package.swift
+++ b/Package.swift
@@ -48,8 +48,8 @@ let package = Package(
     targets: [
         .target(
             name: "CDYelpFusionKit",
-            path: "Source",
             dependencies: [.product(name: "Alamofire", package: "Alamofire")],
+            path: "Source",
             linkerSettings: [.linkedFramework("UIKit", .when(platforms: [.iOS, .tvOS]))]
         ),
     ],

--- a/Package.swift
+++ b/Package.swift
@@ -50,7 +50,7 @@ let package = Package(
             name: "CDYelpFusionKit",
             path: "Source",
             dependencies: [.product(name: "Alamofire", package: "Alamofire")],
-            linkerSettings: [.linkedFramework("UIKit", .when(platforms: [.iOS, .tvOS])]
+            linkerSettings: [.linkedFramework("UIKit", .when(platforms: [.iOS, .tvOS])],
         ),
     ],
     swiftLanguageVersions: [.v5])

--- a/Package.swift
+++ b/Package.swift
@@ -47,6 +47,6 @@ let package = Package(
     targets: [
         .target(
             name: "CDYelpFusionKit",
-            path: "CDYelpFusionKit")
+            path: "Source")
     ],
     swiftLanguageVersions: [.v5])

--- a/Package.swift
+++ b/Package.swift
@@ -50,7 +50,7 @@ let package = Package(
             name: "CDYelpFusionKit",
             path: "Source",
             dependencies: [.product(name: "Alamofire", package: "Alamofire")],
-            linkerSettings: [.linkedFramework("UIKit", .when(platforms: [.iOS, .tvOS])],
+            linkerSettings: [.linkedFramework("UIKit", .when(platforms: [.iOS, .tvOS]))]
         ),
     ],
     swiftLanguageVersions: [.v5])

--- a/Source/CDImage+CDYelpFusionKit.swift
+++ b/Source/CDImage+CDYelpFusionKit.swift
@@ -25,6 +25,12 @@
 //  THE SOFTWARE.
 //
 
+#if !os(OSX)
+ import UIKit
+#else
+ import Foundation
+#endif
+
 public extension CDImage {
 
     private class func cdImage(named name: String!) -> CDImage? {

--- a/Source/CDYelpAPIClient.swift
+++ b/Source/CDYelpAPIClient.swift
@@ -25,6 +25,12 @@
 //  THE SOFTWARE.
 //
 
+#if !os(OSX)
+ import UIKit
+#else
+ import Foundation
+#endif
+
 import Alamofire
 
 public class CDYelpAPIClient: NSObject {

--- a/Source/CDYelpBusiness.swift
+++ b/Source/CDYelpBusiness.swift
@@ -25,6 +25,12 @@
 //  THE SOFTWARE.
 //
 
+#if !os(OSX)
+ import UIKit
+#else
+ import Foundation
+#endif
+
 public struct CDYelpBusiness: Decodable {
 
     public let id: String?

--- a/Source/CDYelpEvent.swift
+++ b/Source/CDYelpEvent.swift
@@ -25,6 +25,12 @@
 //  THE SOFTWARE.
 //
 
+#if !os(OSX)
+ import UIKit
+#else
+ import Foundation
+#endif
+
 public struct CDYelpEvent: Decodable {
 
     public let attendingCount: Int?

--- a/Source/CDYelpReview.swift
+++ b/Source/CDYelpReview.swift
@@ -25,6 +25,12 @@
 //  THE SOFTWARE.
 //
 
+#if !os(OSX)
+ import UIKit
+#else
+ import Foundation
+#endif
+
 public struct CDYelpReview: Decodable {
 
     public let id: String?

--- a/Source/CDYelpRouter.swift
+++ b/Source/CDYelpRouter.swift
@@ -25,6 +25,12 @@
 //  THE SOFTWARE.
 //
 
+#if !os(OSX)
+ import UIKit
+#else
+ import Foundation
+#endif
+
 import Alamofire
 
 enum CDYelpRouter: URLRequestConvertible {

--- a/Source/CDYelpUser.swift
+++ b/Source/CDYelpUser.swift
@@ -25,6 +25,12 @@
 //  THE SOFTWARE.
 //
 
+#if !os(OSX)
+ import UIKit
+#else
+ import Foundation
+#endif
+
 public struct CDYelpUser: Decodable {
 
     public let id: String?

--- a/Source/DateFormatter+CDYelpFusionKit.swift
+++ b/Source/DateFormatter+CDYelpFusionKit.swift
@@ -25,6 +25,12 @@
 //  THE SOFTWARE.
 //
 
+#if !os(OSX)
+ import UIKit
+#else
+ import Foundation
+#endif
+
 extension DateFormatter {
   static let events: DateFormatter = {
    let formatter = DateFormatter()

--- a/Source/Parameters+CDYelpFusionKit.swift
+++ b/Source/Parameters+CDYelpFusionKit.swift
@@ -25,6 +25,12 @@
 //  THE SOFTWARE.
 //
 
+#if !os(OSX)
+ import UIKit
+#else
+ import Foundation
+#endif
+
 import Alamofire
 
 extension Dictionary where Key: ExpressibleByStringLiteral, Value: Any {

--- a/Source/URL+CDYelpFusionKit.swift
+++ b/Source/URL+CDYelpFusionKit.swift
@@ -25,6 +25,12 @@
 //  THE SOFTWARE.
 //
 
+#if !os(OSX)
+ import UIKit
+#else
+ import Foundation
+#endif
+
 public extension URL {
 
     // MARK: - Private Methods


### PR DESCRIPTION
### Issue Link :link:
- Issue is related to the ticket here: https://github.com/chrisdhaan/CDYelpFusionKit/issues/26

### Goals :soccer:
- Ability to add CDYelpFusionKit dependency using Swift Package Manager. No need for CocoaPods anymore!

### Implementation Details :construction:
- Changes made were to resolve compiler errors noted on screen shots in the ticket listed above.

### Testing Details :mag:

- Created a new Swift UI application, added the CDYelpFusionKit using Swift Package Manager
- Created a button to run a "searchBusinessess()" function call to get 3 businesses names. 
- Captured Debug output:

![Screen Shot 2021-08-10 at 12 26 05 AM](https://user-images.githubusercontent.com/47987527/128808142-75e51f04-5c5f-4f6b-beb9-6b203973b6a2.png)
![Screen Shot 2021-08-10 at 12 26 19 AM](https://user-images.githubusercontent.com/47987527/128808172-6a169dd9-cf41-4a68-8fb8-bfb73afc07e8.png)


P.S. sorry about the multiple commits. It was more of a trail and error run! needed this quickly and I don't see a negative impact on effect on other parts of the API. Please let me know what you think.
