### PR TITLE
Fix Decode Error for Yelp returning Invalid ImageURLs & Support alias

### DIFF
--- a/Source/CDYelpBusiness.swift
+++ b/Source/CDYelpBusiness.swift
@@ -54,6 +54,7 @@ public struct CDYelpBusiness: Decodable {
 
     enum CodingKeys: String, CodingKey {
         case id
+        case alias
         case name
         case imageUrl = "image_url"
         case isClosed = "is_closed"

--- a/Source/CDYelpBusiness.swift
+++ b/Source/CDYelpBusiness.swift
@@ -34,8 +34,9 @@
 public struct CDYelpBusiness: Decodable {
 
     public let id: String?
+    public let alias: String?
     public let name: String?
-    public let imageUrl: URL?
+    public let imageUrl: String?
     public let isClosed: Bool?
     public let url: URL?
     public let price: String?


### PR DESCRIPTION
### Issue Link :link:
#32 

### Goals :soccer:
- Support business aliases.
- Fix decode errors in AlamoFire for image_url when Yelp returns blank string image_urls.

### Implementation Details :construction:
- Very minor changes

### Testing Details :mag:
- Several decode errors have been eliminated from my app
