### PR TITLE
Update model Date and URL attributes

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -8,34 +8,29 @@ excluded: # paths to ignore during linting. Takes precedence over `included`.
   - Example/Resources
 
 # configurable rules can be customized from this configuration file.
-# colon behavior when specifying types or defining dictionaries
-colon:
-  apply_to_dictionaries: false
 # complexity of a function
 cyclomatic_complexity:
   error: 60
   warning: 55
 # number of lines allowed in a function
 function_body_length:
-  error: 60
-  warning: 55
+  error: 50
+  warning: 45
 # number of parameters allowed for a function
 function_parameter_count: 15
 # number of lines allowed in a file
 file_length:
-  error: 1200
-  warning: 750
-# rules related to vars/lets
-identifier_name:
-  excluded:
-    - id
+  error: 735
+  warning: 730
 # number of characters allowed in a line
 line_length:
   error: 200
   ignores_comments: true
-  ignores_function_declarations: true
   warning: 195
+# Allow for types to be definied within a struct 1 level deep
+nesting:
+  type_level: 2
 # number of lines allowed in a type declaration
 type_body_length:
-  error: 450
-  warning: 400
+  error: 370
+  warning: 365

--- a/CDYelpFusionKit.podspec
+++ b/CDYelpFusionKit.podspec
@@ -1,11 +1,11 @@
 Pod::Spec.new do |s|
   s.name = 'CDYelpFusionKit'
-  s.version = '3.1.0'
+  s.version = '3.2.0'
   s.license = { :type => 'MIT', :file => 'LICENSE' }
   s.summary = 'An extensive Swift wrapper for the Yelp Fusion API.'
   s.description = <<-DESC
-  This Swift wrapper covers all possible network endpoints and responses for the Yelp Fusion API.
-                         DESC
+    This Swift wrapper covers all possible network endpoints and responses for the Yelp Fusion API.
+  DESC
   s.homepage = 'https://github.com/chrisdhaan/CDYelpFusionKit'
   s.author = { 'Christopher de Haan' => 'contact@christopherdehaan.me' }
   s.source = { :git => 'https://github.com/chrisdhaan/CDYelpFusionKit.git', :tag => s.version.to_s }

--- a/CDYelpFusionKit.xcodeproj/project.pbxproj
+++ b/CDYelpFusionKit.xcodeproj/project.pbxproj
@@ -45,10 +45,22 @@
 		B207F6E02855500900CF53FA /* CDYelpFusionKit.swift in Sources */ = {isa = PBXBuildFile; fileRef = B207F6DE2855500900CF53FA /* CDYelpFusionKit.swift */; };
 		B207F6E12855500900CF53FA /* CDYelpFusionKit.swift in Sources */ = {isa = PBXBuildFile; fileRef = B207F6DE2855500900CF53FA /* CDYelpFusionKit.swift */; };
 		B207F6E22855500900CF53FA /* CDYelpFusionKit.swift in Sources */ = {isa = PBXBuildFile; fileRef = B207F6DE2855500900CF53FA /* CDYelpFusionKit.swift */; };
+		B25A7C7828735E050060E8CD /* CDYelpEventResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = B25A7C7728735E050060E8CD /* CDYelpEventResponse.swift */; };
+		B25A7C7928735E050060E8CD /* CDYelpEventResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = B25A7C7728735E050060E8CD /* CDYelpEventResponse.swift */; };
+		B25A7C7A28735E050060E8CD /* CDYelpEventResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = B25A7C7728735E050060E8CD /* CDYelpEventResponse.swift */; };
+		B25A7C7B28735E050060E8CD /* CDYelpEventResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = B25A7C7728735E050060E8CD /* CDYelpEventResponse.swift */; };
 		B266344D1FBEA1B8003B09CE /* String+CDYelpFusionKit.swift in Sources */ = {isa = PBXBuildFile; fileRef = B266344C1FBEA1B8003B09CE /* String+CDYelpFusionKit.swift */; };
 		B266344E1FBEA1B8003B09CE /* String+CDYelpFusionKit.swift in Sources */ = {isa = PBXBuildFile; fileRef = B266344C1FBEA1B8003B09CE /* String+CDYelpFusionKit.swift */; };
 		B266344F1FBEA1B8003B09CE /* String+CDYelpFusionKit.swift in Sources */ = {isa = PBXBuildFile; fileRef = B266344C1FBEA1B8003B09CE /* String+CDYelpFusionKit.swift */; };
 		B26634501FBEA1B8003B09CE /* String+CDYelpFusionKit.swift in Sources */ = {isa = PBXBuildFile; fileRef = B266344C1FBEA1B8003B09CE /* String+CDYelpFusionKit.swift */; };
+		B267902428592C9E00DFAAA5 /* CDYelpMessaging.swift in Sources */ = {isa = PBXBuildFile; fileRef = B267902328592C9E00DFAAA5 /* CDYelpMessaging.swift */; };
+		B267902528592C9E00DFAAA5 /* CDYelpMessaging.swift in Sources */ = {isa = PBXBuildFile; fileRef = B267902328592C9E00DFAAA5 /* CDYelpMessaging.swift */; };
+		B267902628592C9E00DFAAA5 /* CDYelpMessaging.swift in Sources */ = {isa = PBXBuildFile; fileRef = B267902328592C9E00DFAAA5 /* CDYelpMessaging.swift */; };
+		B267902728592C9E00DFAAA5 /* CDYelpMessaging.swift in Sources */ = {isa = PBXBuildFile; fileRef = B267902328592C9E00DFAAA5 /* CDYelpMessaging.swift */; };
+		B267903128592CDA00DFAAA5 /* CDYelpSpecialHour.swift in Sources */ = {isa = PBXBuildFile; fileRef = B267903028592CDA00DFAAA5 /* CDYelpSpecialHour.swift */; };
+		B267903228592CDA00DFAAA5 /* CDYelpSpecialHour.swift in Sources */ = {isa = PBXBuildFile; fileRef = B267903028592CDA00DFAAA5 /* CDYelpSpecialHour.swift */; };
+		B267903328592CDA00DFAAA5 /* CDYelpSpecialHour.swift in Sources */ = {isa = PBXBuildFile; fileRef = B267903028592CDA00DFAAA5 /* CDYelpSpecialHour.swift */; };
+		B267903428592CDA00DFAAA5 /* CDYelpSpecialHour.swift in Sources */ = {isa = PBXBuildFile; fileRef = B267903028592CDA00DFAAA5 /* CDYelpSpecialHour.swift */; };
 		B267ED56233EAD3C007B902A /* CDYelpCategoriesResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = B267ED55233EAD3C007B902A /* CDYelpCategoriesResponse.swift */; };
 		B267ED57233EAD3C007B902A /* CDYelpCategoriesResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = B267ED55233EAD3C007B902A /* CDYelpCategoriesResponse.swift */; };
 		B267ED58233EAD3C007B902A /* CDYelpCategoriesResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = B267ED55233EAD3C007B902A /* CDYelpCategoriesResponse.swift */; };
@@ -244,7 +256,10 @@
 		B25523B2218D02FF007CDD7A /* .swiftlint.yml */ = {isa = PBXFileReference; lastKnownFileType = text; path = .swiftlint.yml; sourceTree = "<group>"; };
 		B25523C5218D037B007CDD7A /* PULL_REQUEST_TEMPLATE.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; name = PULL_REQUEST_TEMPLATE.md; path = .github/PULL_REQUEST_TEMPLATE.md; sourceTree = "<group>"; };
 		B25523C6218D037B007CDD7A /* ISSUE_TEMPLATE.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; name = ISSUE_TEMPLATE.md; path = .github/ISSUE_TEMPLATE.md; sourceTree = "<group>"; };
+		B25A7C7728735E050060E8CD /* CDYelpEventResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CDYelpEventResponse.swift; sourceTree = "<group>"; };
 		B266344C1FBEA1B8003B09CE /* String+CDYelpFusionKit.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+CDYelpFusionKit.swift"; sourceTree = "<group>"; };
+		B267902328592C9E00DFAAA5 /* CDYelpMessaging.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CDYelpMessaging.swift; sourceTree = "<group>"; };
+		B267903028592CDA00DFAAA5 /* CDYelpSpecialHour.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CDYelpSpecialHour.swift; sourceTree = "<group>"; };
 		B267ED55233EAD3C007B902A /* CDYelpCategoriesResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CDYelpCategoriesResponse.swift; sourceTree = "<group>"; };
 		B267ED5A233EADAB007B902A /* CDYelpCategoryResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CDYelpCategoryResponse.swift; sourceTree = "<group>"; };
 		B285D9E81FBD34F400FA9ABB /* CDYelpFusionKit.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = CDYelpFusionKit.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -382,14 +397,17 @@
 				5FBF0E941EC000B1004C1F6B /* CDYelpCoordinates.swift */,
 				5FBF0E951EC000B1004C1F6B /* CDYelpError.swift */,
 				5FDB32981FAACE8E00A9CF71 /* CDYelpEvent.swift */,
+				B25A7C7728735E050060E8CD /* CDYelpEventResponse.swift */,
 				5FDB32A11FAACF4100A9CF71 /* CDYelpEventsResponse.swift */,
 				5FBF0E971EC000B1004C1F6B /* CDYelpHour.swift */,
 				5FBF0E981EC000B1004C1F6B /* CDYelpLocation.swift */,
+				B267902328592C9E00DFAAA5 /* CDYelpMessaging.swift */,
 				5FBF0E9C1EC000B1004C1F6B /* CDYelpOpen.swift */,
 				5FBF0E9D1EC000B1004C1F6B /* CDYelpRegion.swift */,
 				5FBF0E9E1EC000B1004C1F6B /* CDYelpReview.swift */,
 				5FBF0E9F1EC000B1004C1F6B /* CDYelpReviewsResponse.swift */,
 				5FBF0EA11EC000B1004C1F6B /* CDYelpSearchResponse.swift */,
+				B267903028592CDA00DFAAA5 /* CDYelpSpecialHour.swift */,
 				5FBF0EA21EC000B1004C1F6B /* CDYelpTerm.swift */,
 				5FBF0EA31EC000B1004C1F6B /* CDYelpUser.swift */,
 			);
@@ -800,8 +818,10 @@
 				5FBF0EA91EC000B1004C1F6B /* CDYelpBusinessResponse.swift in Sources */,
 				B267ED56233EAD3C007B902A /* CDYelpCategoriesResponse.swift in Sources */,
 				5FBF0EAA1EC000B1004C1F6B /* CDYelpCategory.swift in Sources */,
+				B25A7C7828735E050060E8CD /* CDYelpEventResponse.swift in Sources */,
 				B267ED5B233EADAB007B902A /* CDYelpCategoryResponse.swift in Sources */,
 				5FBF0EAB1EC000B1004C1F6B /* CDYelpCenter.swift in Sources */,
+				B267903128592CDA00DFAAA5 /* CDYelpSpecialHour.swift in Sources */,
 				5FBF0EAC1EC000B1004C1F6B /* CDYelpConstants.swift in Sources */,
 				5FBF0EAD1EC000B1004C1F6B /* CDYelpCoordinates.swift in Sources */,
 				5F09D2EA1F282938001877E9 /* CDYelpEnums.swift in Sources */,
@@ -819,6 +839,7 @@
 				5FBF0EB91EC000B1004C1F6B /* CDYelpRouter.swift in Sources */,
 				5FBF0EBA1EC000B1004C1F6B /* CDYelpSearchResponse.swift in Sources */,
 				5FBF0EBB1EC000B1004C1F6B /* CDYelpTerm.swift in Sources */,
+				B267902428592C9E00DFAAA5 /* CDYelpMessaging.swift in Sources */,
 				5FBF0EBC1EC000B1004C1F6B /* CDYelpUser.swift in Sources */,
 				5FBF0EBE1EC000B1004C1F6B /* Parameters+CDYelpFusionKit.swift in Sources */,
 				B266344D1FBEA1B8003B09CE /* String+CDYelpFusionKit.swift in Sources */,
@@ -840,8 +861,10 @@
 				B285DA001FBD35C100FA9ABB /* CDYelpBusinessResponse.swift in Sources */,
 				B267ED57233EAD3C007B902A /* CDYelpCategoriesResponse.swift in Sources */,
 				B285DA011FBD35C100FA9ABB /* CDYelpCategory.swift in Sources */,
+				B25A7C7928735E050060E8CD /* CDYelpEventResponse.swift in Sources */,
 				B267ED5C233EADAB007B902A /* CDYelpCategoryResponse.swift in Sources */,
 				B285DA021FBD35C100FA9ABB /* CDYelpCenter.swift in Sources */,
+				B267903228592CDA00DFAAA5 /* CDYelpSpecialHour.swift in Sources */,
 				B285DA141FBD35C100FA9ABB /* CDYelpConstants.swift in Sources */,
 				B285DA031FBD35C100FA9ABB /* CDYelpCoordinates.swift in Sources */,
 				B285DA151FBD35C100FA9ABB /* CDYelpEnums.swift in Sources */,
@@ -859,6 +882,7 @@
 				B285DA161FBD35C100FA9ABB /* CDYelpRouter.swift in Sources */,
 				B285DA0D1FBD35C100FA9ABB /* CDYelpSearchResponse.swift in Sources */,
 				B285DA0E1FBD35C100FA9ABB /* CDYelpTerm.swift in Sources */,
+				B267902528592C9E00DFAAA5 /* CDYelpMessaging.swift in Sources */,
 				B285DA0F1FBD35C100FA9ABB /* CDYelpUser.swift in Sources */,
 				B285D9FB1FBD35C100FA9ABB /* Parameters+CDYelpFusionKit.swift in Sources */,
 				B266344E1FBEA1B8003B09CE /* String+CDYelpFusionKit.swift in Sources */,
@@ -880,8 +904,10 @@
 				B285DA441FBE1BCE00FA9ABB /* CDYelpBusinessResponse.swift in Sources */,
 				B267ED58233EAD3C007B902A /* CDYelpCategoriesResponse.swift in Sources */,
 				B285DA451FBE1BCE00FA9ABB /* CDYelpCategory.swift in Sources */,
+				B25A7C7A28735E050060E8CD /* CDYelpEventResponse.swift in Sources */,
 				B267ED5D233EADAB007B902A /* CDYelpCategoryResponse.swift in Sources */,
 				B285DA461FBE1BCE00FA9ABB /* CDYelpCenter.swift in Sources */,
+				B267903328592CDA00DFAAA5 /* CDYelpSpecialHour.swift in Sources */,
 				B285DA581FBE1BCE00FA9ABB /* CDYelpConstants.swift in Sources */,
 				B285DA471FBE1BCE00FA9ABB /* CDYelpCoordinates.swift in Sources */,
 				B285DA591FBE1BCE00FA9ABB /* CDYelpEnums.swift in Sources */,
@@ -899,6 +925,7 @@
 				B285DA5A1FBE1BCE00FA9ABB /* CDYelpRouter.swift in Sources */,
 				B285DA511FBE1BCE00FA9ABB /* CDYelpSearchResponse.swift in Sources */,
 				B285DA521FBE1BCE00FA9ABB /* CDYelpTerm.swift in Sources */,
+				B267902628592C9E00DFAAA5 /* CDYelpMessaging.swift in Sources */,
 				B285DA531FBE1BCE00FA9ABB /* CDYelpUser.swift in Sources */,
 				B285DA3F1FBE1BCE00FA9ABB /* Parameters+CDYelpFusionKit.swift in Sources */,
 				B266344F1FBEA1B8003B09CE /* String+CDYelpFusionKit.swift in Sources */,
@@ -920,8 +947,10 @@
 				B2C6E1FE1FBCF3A400FE8462 /* CDYelpBusinessResponse.swift in Sources */,
 				B267ED59233EAD3C007B902A /* CDYelpCategoriesResponse.swift in Sources */,
 				B2C6E1FF1FBCF3A400FE8462 /* CDYelpCategory.swift in Sources */,
+				B25A7C7B28735E050060E8CD /* CDYelpEventResponse.swift in Sources */,
 				B267ED5E233EADAB007B902A /* CDYelpCategoryResponse.swift in Sources */,
 				B2C6E2001FBCF3A400FE8462 /* CDYelpCenter.swift in Sources */,
+				B267903428592CDA00DFAAA5 /* CDYelpSpecialHour.swift in Sources */,
 				B2C6E2121FBCF3A400FE8462 /* CDYelpConstants.swift in Sources */,
 				B2C6E2011FBCF3A400FE8462 /* CDYelpCoordinates.swift in Sources */,
 				B2C6E2131FBCF3A400FE8462 /* CDYelpEnums.swift in Sources */,
@@ -939,6 +968,7 @@
 				B2C6E2141FBCF3A400FE8462 /* CDYelpRouter.swift in Sources */,
 				B2C6E20B1FBCF3A400FE8462 /* CDYelpSearchResponse.swift in Sources */,
 				B2C6E20C1FBCF3A400FE8462 /* CDYelpTerm.swift in Sources */,
+				B267902728592C9E00DFAAA5 /* CDYelpMessaging.swift in Sources */,
 				B2C6E20D1FBCF3A400FE8462 /* CDYelpUser.swift in Sources */,
 				B2C6E1F91FBCF3A400FE8462 /* Parameters+CDYelpFusionKit.swift in Sources */,
 				B26634501FBEA1B8003B09CE /* String+CDYelpFusionKit.swift in Sources */,
@@ -1004,7 +1034,7 @@
 				INFOPLIST_FILE = Source/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				MACOSX_DEPLOYMENT_TARGET = 10.12;
-				MARKETING_VERSION = 3.1.0;
+				MARKETING_VERSION = 3.2.0;
 				ONLY_ACTIVE_ARCH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.christopherdehaan.CDYelpFusionKit;
 				PRODUCT_NAME = CDYelpFusionKit;
@@ -1066,7 +1096,7 @@
 				INFOPLIST_FILE = Source/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				MACOSX_DEPLOYMENT_TARGET = 10.12;
-				MARKETING_VERSION = 3.1.0;
+				MARKETING_VERSION = 3.2.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.christopherdehaan.CDYelpFusionKit;
 				PRODUCT_NAME = CDYelpFusionKit;
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@ All notable changes to this project will be documented in this file.
 `CDYelpFusionKit` adheres to [Semantic Versioning](https://semver.org/).
 
 #### 3.x Releases
-- `3.0.x` Releases - [3.1.0](#310)
+- `3.2.x` Releases - [3.2.0](#320)
+- `3.1.x` Releases - [3.1.0](#310)
 - `3.0.x` Releases - [3.0.0](#300) | [3.0.1](#301)
 
 #### 2.x Releases
@@ -20,17 +21,59 @@ All notable changes to this project will be documented in this file.
 
 ---
 
+## [3.2.0](https://github.com/chrisdhaan/CDYelpFusionKit/releases/tag/3.2.0)
+## Models and Enums
+Released on 2022-08-02.
+
+#### Added
+
+- [x] Models
+    - [x] `CDYelpBusiness.BusinessSearch`, `CDYelpBusiness.PhoneSearch`, `CDYelpBusiness.TransactionSearch`, `CDYelpBusiness.Detailed`, `CDYelpBusiness.BusinessMatch`, and `CDYelpBusiness.Autocomplete` structs
+    - [x] `CDYelpCategoriesResponse.error`
+    - [x] `CDYelpCategory.Detailed` struct
+    - [x] `CDYelpCategoryResponse.error`
+    - [x] `CDYelpEventResponse` struct
+    - [x] `CDYelpLocation.Detailed` struct
+    - [x] `CDYelpMessaging` struct
+    - [x] `CDYelpSearchResponse.Business`, `CDYelpSearchResponse.Phone`, `CDYelpSearchResponse.Transaction`, and `CDYelpSearchResponse.BusinessMatch` structs
+    - [x] `CDYelpSpecialHour` struct
+    - [x] `toDate` methods for `String` representations
+    - [x] `toUrl` methods for `String` representations
+
+#### Updated
+    
+- [x] Models
+    - [x] `@escaping (CDYelpSearchResponse?)` becomes `@escaping (CDYelpSearchResponse.Business?)`
+    - [x] `@escaping (CDYelpSearchResponse?)` becomes `@escaping (CDYelpSearchResponse.Phone?)`
+    - [x] `@escaping (CDYelpSearchResponse?)` becomes `@escaping (CDYelpSearchResponse.Transaction?)`
+    - [x] `@escaping (CDYelpBusiness?)` becomes `@escaping (CDYelpBusinessResponse?)`
+    - [x] `@escaping (CDYelpSearchResponse?)` becomes `@escaping (CDYelpSearchResponse.BusinessMatch?)`
+    - [x] `@escaping (CDYelpEvent?)` becomes `@escaping (CDYelpEventResponse?)`
+    - [x] `CDYelpAutocompleteResponse.businesses` type becomes `[CDYelpBusiness.Autocomplete]`
+    - [x] `CDYelpBusinessResponse.business` type becomes `CDYelpBusiness.Detailed`
+    - [x] `CDYelpCategoriesResponse.categories` type becomes `[CDYelpCategory.Detailed]`
+    - [x] `CDYelpCategoryResponse.category` type becomes `CDYelpCategory.Detailed`
+    - [x] `Date` types to `String`
+    - [x] `URL` types to `String`
+
+#### Removed
+
+- [x] CDYelpEnums
+    - [x] `CDYelpAttributeFilter.cashback`, `CDYelpTransactionType.pickup`, and `CDYelpTransactionType.restaurantReservation`
+
+---
+
 ## [3.1.0](https://github.com/chrisdhaan/CDYelpFusionKit/releases/tag/3.1.0)
 ## SDK Support
 Released on 2022-06-13.
 
 #### Added
 
-- [x] Swift 5.6
+- [x] Swift 5.4, 5.5, and 5.6
 
 #### Updated
     
-- [x] Switch Package Manager
+- [x] Swift Package Manager
     - [x] Minimum Swift version 5.3
 - [x] Dependencies
     - [x] Alamofire
@@ -44,6 +87,7 @@ Released on 2022-06-13.
 Released on 2021-09-17.
 
 #### Added
+
 - [x] CI
     - [x] macOS 5.1 test
     - [x] macOS 5.2 test
@@ -51,7 +95,7 @@ Released on 2021-09-17.
 
 #### Updated
 
-- [x] Switch Package Manager
+- [x] Swift Package Manager
     - [x] Configuration
 
 ---
@@ -61,6 +105,7 @@ Released on 2021-09-17.
 Released on 2021-09-12.
 
 #### Added
+
 - [x] Client
     - [x] `validate` to API methods
 
@@ -74,10 +119,11 @@ Released on 2021-09-12.
     - [x] `var` to `let`
 - [x] Dependencies
     - [x] Alamofire
-- [x] Switch Package Manager
+- [x] Swift Package Manager
     - [x] Configuration
 
 #### Removed
+
 - [x] Dependencies
     - [x] ObjectMapper
 - [x] Travis CI

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,6 +8,7 @@ Please read it before you start participating.
 * [Asking Questions](#asking-questions)
 * [Reporting Security Issues](#reporting-security-issues)
 * [Reporting Issues](#reporting-other-issues)
+* [Submitting Pull Requests](#submitting-pull-requests)
 * [Developers Certificate of Origin](#developers-certificate-of-origin)
 * [Code of Conduct](#code-of-conduct)
 

--- a/Example/Resources/Info.plist
+++ b/Example/Resources/Info.plist
@@ -16,8 +16,6 @@
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
 	<string>1.0</string>
-	<key>CFBundleSignature</key>
-	<string>????</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>LSRequiresIPhoneOS</key>
@@ -30,16 +28,6 @@
 	<array>
 		<string>armv7</string>
 	</array>
-	<key>UIStatusBarTintParameters</key>
-	<dict>
-		<key>UINavigationBar</key>
-		<dict>
-			<key>Style</key>
-			<string>UIBarStyleDefault</string>
-			<key>Translucent</key>
-			<false/>
-		</dict>
-	</dict>
 	<key>UISupportedInterfaceOrientations</key>
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>

--- a/Example/Source/CDYelpFusionKitManager.swift
+++ b/Example/Source/CDYelpFusionKitManager.swift
@@ -35,7 +35,7 @@ final class CDYelpFusionKitManager: NSObject {
     var apiClient: CDYelpAPIClient!
 
     func configure() {
-        // How to authorize using your clientId and clientSecret
         self.apiClient = CDYelpAPIClient(apiKey: "YOUR_API_KEY")
+        // How to authorize using your apiKey
     }
 }

--- a/Example/Source/ViewController.swift
+++ b/Example/Source/ViewController.swift
@@ -249,8 +249,9 @@ extension ViewController: UITableViewDelegate {
                 }
             case 3:
                 CDYelpFusionKitManager.shared.apiClient.fetchBusiness(forId: "north-india-restaurant-san-francisco",
-                                                                      locale: nil) { (business) in
-                    if let business = business {
+                                                                      locale: nil) { (response) in
+                    if let response = response,
+                       let business = response.business {
                         print(business)
                     }
                 }
@@ -305,9 +306,10 @@ extension ViewController: UITableViewDelegate {
                     }
                 }
             case 7:
-                CDYelpFusionKitManager.shared.apiClient.fetchEvent(forId: "san-francisco-yelp-celebrates-pride-month-2021",
-                                                                   locale: nil) { (event) in
-                    if let event = event {
+                CDYelpFusionKitManager.shared.apiClient.fetchEvent(forId: "san-francisco-yelp-elite-week-renew-and-rejuvenate-with-redmint",
+                                                                   locale: nil) { (response) in
+                    if let response = response,
+                       let event = response.event {
                         print(event)
                     }
                 }
@@ -336,8 +338,9 @@ extension ViewController: UITableViewDelegate {
                 CDYelpFusionKitManager.shared.apiClient.fetchFeaturedEvent(forLocale: nil,
                                                                            location: nil,
                                                                            latitude: 37.786572,
-                                                                           longitude: -122.415192) { (event) in
-                    if let event = event {
+                                                                           longitude: -122.415192) { (response) in
+                    if let response = response,
+                       let event = response.event {
                         print(event)
                     }
                 }

--- a/README.md
+++ b/README.md
@@ -20,8 +20,8 @@
     <a href="https://github.com/chrisdhaan/CDYelpFusionKit/releases">
         <img src="https://img.shields.io/github/release/chrisdhaan/CDYelpFusionKit.svg" alt="GitHub Release">
     </a>
-    <a href="http://cocoapods.org/pods/CDYelpFusionKit">
-        <img src="https://img.shields.io/badge/Swift-5.3_5.4_5.5_5.6-Orange?style=flat-square" alt="Swift">
+    <a href="https://www.swift.org">
+        <img src="https://img.shields.io/badge/Swift-5.3_5.4_5.5_5.6-orange?style=flat" alt="Swift Versions">
     </a>
     <a href="http://cocoapods.org/pods/CDYelpFusionKit">
         <img src="https://img.shields.io/cocoapods/p/CDYelpFusionKit.svg?style=flat" alt="Platforms">
@@ -31,6 +31,9 @@
     </a>
     <a href="https://github.com/Carthage/Carthage">
         <img src="https://img.shields.io/badge/Carthage-compatible-4BC51D.svg?style=flat" alt="Carthage Compatible">
+    </a>
+    <a href="https://www.swift.org/package-manager">
+        <img src="https://img.shields.io/badge/Swift_Package_Manager-compatible-orange?style=flat" alt="Swift Package Manager Compatible">
     </a>
     <a href="http://cocoapods.org/pods/CDYelpFusionKit">
         <img src="https://img.shields.io/cocoapods/l/CDYelpFusionKit.svg?style=flat" alt="License">
@@ -122,7 +125,7 @@ For a demonstration of the capabilities of CDYelpFusionKit; run the iOS Example 
 [CocoaPods](https://cocoapods.org) is a dependency manager for Cocoa projects. For usage and installation instructions, visit their website. To integrate CDYelpFusionKit into your Xcode project using CocoaPods, specify it in your `Podfile`:
 
 ```ruby
-pod 'CDYelpFusionKit', '3.1.0'
+pod 'CDYelpFusionKit', '3.2.0'
 ```
 
 ### Carthage
@@ -130,7 +133,7 @@ pod 'CDYelpFusionKit', '3.1.0'
 [Carthage](https://github.com/Carthage/Carthage) is a decentralized dependency manager that builds your dependencies and provides you with binary frameworks. To integrate CDYelpFusionKit into your Xcode project using Carthage, specify it in your `Cartfile`:
 
 ```ogdl
-github "chrisdhaan/CDYelpFusionKit" == 3.1.0
+github "chrisdhaan/CDYelpFusionKit" == 3.2.0
 ```
 
 ### Swift Package Manager
@@ -141,7 +144,7 @@ Once you have your Swift package set up, adding CDYelpFusionKit as a dependency 
 
 ```swift
 dependencies: [
-    .package(url: "https://github.com/chrisdhaan/CDYelpFusionKit.git", .upToNextMajor(from: "3.1.0"))
+    .package(url: "https://github.com/chrisdhaan/CDYelpFusionKit.git", .upToNextMajor(from: "3.2.0"))
 ]
 ```
 
@@ -219,7 +222,7 @@ public func searchBusinesses(byTerm term: String?,                 // Optional
                              openNow: Bool?,                       // Optional - Default = false
                              openAt: Int?,                         // Optional
                              attributes: [CDYelpAttributeFilter]?, // Optional
-                             completion: @escaping (CDYelpSearchResponse?) -> Void);
+                             completion: @escaping (CDYelpSearchResponse.Business?) -> Void);
 ```
 
 The search endpoint has a `categories` parameter which allows for query results to be returned based off one thousand four hundred and sixty-one types of categories. The full list of categories can be found in `CDYelpEnums.swift`. The following lines of code show an example of a category that can be passed into the `categories` parameter.
@@ -298,9 +301,12 @@ The search endpoint has an `attributes` parameter which allows for query results
 ```swift
 CDYelpAttributeFilter.hotAndNew
 CDYelpAttributeFilter.requestAQuote
+CDYelpAttributeFilter.reservation
 CDYelpAttributeFilter.waitlistReservation
-CDYelpAttributeFilter.cashback
 CDYelpAttributeFilter.deals
+CDYelpAttributeFilter.genderNeutralRestrooms
+CDYelpAttributeFilter.openToAll
+CDYelpAttributeFilter.wheelchairAccessible
 ```
 
 The following lines of code show an example query to the search endpoint.
@@ -336,7 +342,7 @@ yelpAPIClient.searchBusinesses(byTerm: "Food",
 
 ```swift
 public func searchBusinesses(byPhoneNumber phoneNumber: String!, // Required
-                             completion: @escaping (CDYelpSearchResponse?) -> Void)
+                             completion: @escaping (CDYelpSearchResponse.Phone?) -> Void)
 ```
 
 The following lines of code show an example query to the phone search endpoint.
@@ -359,7 +365,7 @@ public func searchTransactions(byType type: CDYelpTransactionType!, // Required
                               location: String?,                    // Optional
                               latitude: Double?,                    // Optional
                               longitude: Double?,                   // Optional
-                              completion: @escaping (CDYelpSearchResponse?) -> Void)
+                              completion: @escaping (CDYelpSearchResponse.Transaction?) -> Void)
 ```
 
 The transactions search endpoint has a `type` parameter which allows for query results to be filtered based off one type of criteria. The following lines of code show which transaction types can be passed into the `byType` parameter.
@@ -389,7 +395,7 @@ yelpAPIClient.searchTransactions(byType: .foodDelivery,
 ```swift
 public func fetchBusiness(forId id: String!,     // Required
                           locale: CDYelpLocale?, // Optional
-                          completion: @escaping (CDYelpBusiness?) -> Void)
+                          completion: @escaping (CDYelpBusinessResponse?) -> Void)
 ```
 
 The following lines of code show an example query to the business endpoint.
@@ -398,7 +404,8 @@ The following lines of code show an example query to the business endpoint.
 yelpAPIClient.fetchBusiness(forId: "north-india-restaurant-san-francisco"
                             locale: nil) { (business) in
 
-  if let business = business {
+  if let response = response,
+      let business = response.business {
       print(business)
   }
 }
@@ -421,7 +428,7 @@ public func searchBusinesses(name: String!,                                     
                              yelpBusinessId: String?,                              // Optional
                              limit: Int?,                                          // Optional - Min = 1, Default = 3, Max = 10
                              matchThresholdType: CDYelpBusinessMatchThresholdType, // Required
-                             completion: @escaping (CDYelpSearchResponse?) -> Void)
+                             completion: @escaping (CDYelpSearchResponse.BusinessMatch?) -> Void)
 ```
 
 The business match endpoint has a `matchThresholdType` parameter which allows for query results to be filtered based off three types of criteria. The following lines of code show which business match threshold types can be passed into the `matchThresholdType` parameter.
@@ -515,7 +522,7 @@ yelpAPIClient.autocompleteBusinesses(byText: "Pizza Delivery",
 ```swift
 public func fetchEvent(forId id: String!,     // Required
                        locale: CDYelpLocale?, // Optional
-                       completion: @escaping (CDYelpEvent?) -> Void)
+                       completion: @escaping (CDYelpEventResponse?) -> Void)
 ```
 
 The event lookup endpoint has a `locale` parameter which allows for query results to be returned based off forty-two types of language and country codes. Refer to the [search endpoint](#search-endpoint) for information regarding using the `locale` parameter.
@@ -526,7 +533,8 @@ The following lines of code show an example query to the event lookup endpoint.
 yelpAPIClient.fetchEvent(forId: "san-francisco-yelp-celebrates-pride-month-2021",
                          locale: nil) { (event) in
 
-  if let event = event {
+  if let response = response,
+      event = response.event {
       print(event)
   }
 }
@@ -619,7 +627,7 @@ public func fetchFeaturedEvent(forLocale locale: CDYelpLocale?, // Optional
                                location: String?,               // Optional
                                latitude: Double?,               // Optional
                                longitude: Double?,              // Optional
-                               completion: @escaping (CDYelpEvent?) -> Void)
+                               completion: @escaping (CDYelpEventResponse?) -> Void)
 ```
 
 The featured event endpoint has a `locale` parameter which allows for query results to be returned based off forty-two types of language and country codes. Refer to the [search endpoint](#search-endpoint) for information regarding using the `locale` parameter.
@@ -632,7 +640,8 @@ yelpAPIClient.fetchFeaturedEvent(forLocale: nil,
                                  latitude: 37.786572,
                                  longitude: -122.415192) { (event) in
 
-  if let event = event {
+  if let response = response,
+      event = response.event {
       print(event)
   }
 }

--- a/Source/CDYelpAPIClient.swift
+++ b/Source/CDYelpAPIClient.swift
@@ -125,7 +125,7 @@ public class CDYelpAPIClient: NSObject {
                                  openNow: Bool?,
                                  openAt: Int?,
                                  attributes: [CDYelpAttributeFilter]?,
-                                 completion: @escaping (CDYelpSearchResponse?) -> Void) {
+                                 completion: @escaping (CDYelpSearchResponse.Business?) -> Void) {
         assert((latitude != nil && longitude != nil) ||
                 (location != nil), "Either a latitude and longitude or a location are required to query the Yelp Fusion API search endpoint.")
         if let radius = radius {
@@ -155,7 +155,7 @@ public class CDYelpAPIClient: NSObject {
             self.manager
                 .request(CDYelpRouter.search(parameters: parameters))
                 .validate()
-                .responseDecodable { (response: DataResponse<CDYelpSearchResponse, AFError>) in
+                .responseDecodable { (response: DataResponse<CDYelpSearchResponse.Business, AFError>) in
 
                     switch response.result {
                     case .success(let searchResponse):
@@ -181,7 +181,7 @@ public class CDYelpAPIClient: NSObject {
     /// - returns: (CDYelpSearchResponse?) -> Void
     ///
     public func searchBusinesses(byPhoneNumber phoneNumber: String!,
-                                 completion: @escaping (CDYelpSearchResponse?) -> Void) {
+                                 completion: @escaping (CDYelpSearchResponse.Phone?) -> Void) {
         assert((phoneNumber != nil && phoneNumber.count > 0), "A business phone number is required to query the Yelp Fusion API phone endpoint.")
 
         if self.isAuthenticated() == true {
@@ -191,7 +191,7 @@ public class CDYelpAPIClient: NSObject {
             self.manager
                 .request(CDYelpRouter.phone(parameters: parameters))
                 .validate()
-                .responseDecodable { (response: DataResponse<CDYelpSearchResponse, AFError>) in
+                .responseDecodable { (response: DataResponse<CDYelpSearchResponse.Phone, AFError>) in
 
                     switch response.result {
                     case .success(let searchResponse):
@@ -223,7 +223,7 @@ public class CDYelpAPIClient: NSObject {
                                    location: String?,
                                    latitude: Double?,
                                    longitude: Double?,
-                                   completion: @escaping (CDYelpSearchResponse?) -> Void) {
+                                   completion: @escaping (CDYelpSearchResponse.Transaction?) -> Void) {
         assert(type != nil, "A transaction type is required to query the Yelp Fusion API transactions endpoint.")
         assert((latitude != nil && longitude != nil) ||
                 (location != nil), "Either a latitude and longitude or a location are required to query the Yelp Fusion API transactions endpoint.")
@@ -238,7 +238,7 @@ public class CDYelpAPIClient: NSObject {
                 .request(CDYelpRouter.transactions(type: type.rawValue,
                                                    parameters: parameters))
                 .validate()
-                .responseDecodable { (response: DataResponse<CDYelpSearchResponse, AFError>) in
+                .responseDecodable { (response: DataResponse<CDYelpSearchResponse.Transaction, AFError>) in
 
                     switch response.result {
                     case .success(let searchResponse):
@@ -265,7 +265,7 @@ public class CDYelpAPIClient: NSObject {
     ///
     public func fetchBusiness(forId id: String!,
                               locale: CDYelpLocale?,
-                              completion: @escaping (CDYelpBusiness?) -> Void) {
+                              completion: @escaping (CDYelpBusinessResponse?) -> Void) {
         assert((id != nil && id.count > 0), "A business id is required to query the Yelp Fusion API business endpoint.")
 
         if self.isAuthenticated() == true {
@@ -276,7 +276,7 @@ public class CDYelpAPIClient: NSObject {
                 .request(CDYelpRouter.business(id: id,
                                                parameters: parameters))
                 .validate()
-                .responseDecodable { (response: DataResponse<CDYelpBusiness, AFError>) in
+                .responseDecodable { (response: DataResponse<CDYelpBusinessResponse, AFError>) in
 
                     switch response.result {
                     case .success(let business):
@@ -325,7 +325,7 @@ public class CDYelpAPIClient: NSObject {
                                  yelpBusinessId: String?,
                                  limit: Int?,
                                  matchThresholdType: CDYelpBusinessMatchThresholdType!,
-                                 completion: @escaping (CDYelpSearchResponse?) -> Void) {
+                                 completion: @escaping (CDYelpSearchResponse.BusinessMatch?) -> Void) {
         assert((name != nil && name.count > 0 && name.count <= 64), "A name (containing no more than 64 characters) is required to query the Yelp Fusion API business match endpoint.")
         assert((addressOne != nil && addressOne.count > 0 && addressOne.count <= 64), "addressOne must contain no more than 64 characters to query the Yelp Fusion API business match endpoint.")
         if let addressTwo = addressTwo {
@@ -371,7 +371,7 @@ public class CDYelpAPIClient: NSObject {
             self.manager
                 .request(CDYelpRouter.matches(parameters: parameters))
                 .validate()
-                .responseDecodable { (response: DataResponse<CDYelpSearchResponse, AFError>) in
+                .responseDecodable { (response: DataResponse<CDYelpSearchResponse.BusinessMatch, AFError>) in
 
                     switch response.result {
                     case .success(let searchResponse):
@@ -490,7 +490,7 @@ public class CDYelpAPIClient: NSObject {
     ///
     public func fetchEvent(forId id: String!,
                            locale: CDYelpLocale?,
-                           completion: @escaping (CDYelpEvent?) -> Void) {
+                           completion: @escaping (CDYelpEventResponse?) -> Void) {
         assert((id != nil && id.count > 0), "An event id is required to query the Yelp Fusion API event endpoint.")
 
         if self.isAuthenticated() == true {
@@ -504,7 +504,7 @@ public class CDYelpAPIClient: NSObject {
                                             parameters: parameters))
                 .validate()
                 .responseDecodable(decoder: decoder,
-                                   completionHandler: { (response: DataResponse<CDYelpEvent, AFError>) in
+                                   completionHandler: { (response: DataResponse<CDYelpEventResponse, AFError>) in
                                     switch response.result {
                                     case .success(let event):
                                         completion(event)
@@ -614,7 +614,7 @@ public class CDYelpAPIClient: NSObject {
                                    location: String?,
                                    latitude: Double?,
                                    longitude: Double?,
-                                   completion: @escaping (CDYelpEvent?) -> Void) {
+                                   completion: @escaping (CDYelpEventResponse?) -> Void) {
         assert((latitude != nil && longitude != nil) ||
                 (location != nil), "Either a latitude and longitude or a location are required to query the Yelp Fusion API featured event endpoint.")
 
@@ -631,7 +631,7 @@ public class CDYelpAPIClient: NSObject {
                 .request(CDYelpRouter.featuredEvent(parameters: parameters))
                 .validate()
                 .responseDecodable(decoder: decoder,
-                                   completionHandler: { (response: DataResponse<CDYelpEvent, AFError>) in
+                                   completionHandler: { (response: DataResponse<CDYelpEventResponse, AFError>) in
                                     switch response.result {
                                     case .success(let event):
                                         completion(event)

--- a/Source/CDYelpAutoCompleteResponse.swift
+++ b/Source/CDYelpAutoCompleteResponse.swift
@@ -28,7 +28,7 @@
 public struct CDYelpAutoCompleteResponse: Decodable {
 
     public let terms: [CDYelpTerm]?
-    public let businesses: [CDYelpBusiness]?
+    public let businesses: [CDYelpBusiness.Autocomplete]?
     public let categories: [CDYelpCategory]?
     public let error: CDYelpError?
 

--- a/Source/CDYelpBusiness.swift
+++ b/Source/CDYelpBusiness.swift
@@ -31,43 +31,268 @@
     import Foundation
 #endif
 
-public struct CDYelpBusiness: Decodable {
+public struct CDYelpBusiness {
+    public struct BusinessSearch: Decodable {
 
-    public let id: String?
-    public let name: String?
-    public let imageUrl: URL?
-    public let isClosed: Bool?
-    public let url: URL?
-    public let price: String?
-    public let phone: String?
-    public let displayPhone: String?
-    public let photos: [String]?
-    public let hours: [CDYelpHour]?
-    public let rating: Double?
-    public let reviewCount: Int?
-    public let categories: [CDYelpCategory]?
-    public let distance: Double?
-    public let coordinates: CDYelpCoordinates?
-    public let location: CDYelpLocation?
-    public let transactions: [String]?
+        public let categories: [CDYelpCategory]?
+        public let coordinates: CDYelpCoordinates?
+        public let displayPhone: String?
+        public let distance: Double?
+        public let id: String?
+        public let alias: String?
+        public let imageUrl: String?
+        public let isClosed: Bool?
+        public let location: CDYelpLocation.Detailed?
+        public let name: String?
+        public let phone: String?
+        public let price: String?
+        public let rating: Double?
+        public let reviewCount: Int?
+        public let url: String?
+        public let transactions: [String]?
 
-    enum CodingKeys: String, CodingKey {
-        case id
-        case name
-        case imageUrl = "image_url"
-        case isClosed = "is_closed"
-        case url
-        case price
-        case phone
-        case displayPhone = "display_phone"
-        case photos
-        case hours
-        case rating
-        case reviewCount = "review_count"
-        case categories
-        case distance
-        case coordinates
-        case location
-        case transactions
+        enum CodingKeys: String, CodingKey {
+            case categories
+            case coordinates
+            case displayPhone = "display_phone"
+            case distance
+            case id
+            case alias
+            case imageUrl = "image_url"
+            case isClosed = "is_closed"
+            case location
+            case name
+            case phone
+            case price
+            case rating
+            case reviewCount = "review_count"
+            case url
+            case transactions
+        }
+
+        public func imageUrlAsUrl() -> URL? {
+            if let imageUrl = self.imageUrl,
+               let asUrl = URL(string: imageUrl) {
+                return asUrl
+            }
+            return nil
+        }
+
+        public func urlAsUrl() -> URL? {
+            if let url = self.url,
+               let asUrl = URL(string: url) {
+                return asUrl
+            }
+            return nil
+        }
+    }
+
+    public struct PhoneSearch: Decodable {
+
+        public let id: String?
+        public let alias: String?
+        public let name: String?
+        public let imageUrl: String?
+        public let isClosed: Bool?
+        public let url: String?
+        public let price: String?
+        public let phone: String?
+        public let rating: Double?
+        public let reviewCount: Int?
+        public let categories: [CDYelpCategory]?
+        public let coordinates: CDYelpCoordinates?
+        public let location: CDYelpLocation?
+        public let transactions: [String]?
+
+        enum CodingKeys: String, CodingKey {
+            case id
+            case alias
+            case name
+            case imageUrl = "image_url"
+            case isClosed = "is_closed"
+            case url
+            case price
+            case phone
+            case rating
+            case reviewCount = "review_count"
+            case categories
+            case coordinates
+            case location
+            case transactions
+        }
+
+        public func imageUrlAsUrl() -> URL? {
+            if let imageUrl = self.imageUrl,
+               let asUrl = URL(string: imageUrl) {
+                return asUrl
+            }
+            return nil
+        }
+
+        public func urlAsUrl() -> URL? {
+            if let url = self.url,
+               let asUrl = URL(string: url) {
+                return asUrl
+            }
+            return nil
+        }
+    }
+
+    public struct TransactionSearch: Decodable {
+
+        public let id: String?
+        public let alias: String?
+        public let name: String?
+        public let imageUrl: String?
+        public let isClosed: Bool?
+        public let url: String?
+        public let price: String?
+        public let phone: String?
+        public let rating: Double?
+        public let reviewCount: Int?
+        public let categories: [CDYelpCategory]?
+        public let coordinates: CDYelpCoordinates?
+        public let location: CDYelpLocation?
+        public let transactions: [String]?
+
+        enum CodingKeys: String, CodingKey {
+            case id
+            case alias
+            case name
+            case imageUrl = "image_url"
+            case isClosed = "is_closed"
+            case url
+            case price
+            case phone
+            case rating
+            case reviewCount = "review_count"
+            case categories
+            case coordinates
+            case location
+            case transactions
+        }
+
+        public func imageUrlAsUrl() -> URL? {
+            if let imageUrl = self.imageUrl,
+               let asUrl = URL(string: imageUrl) {
+                return asUrl
+            }
+            return nil
+        }
+
+        public func urlAsUrl() -> URL? {
+            if let url = self.url,
+               let asUrl = URL(string: url) {
+                return asUrl
+            }
+            return nil
+        }
+    }
+
+    public struct Detailed: Decodable {
+
+        public let categories: [CDYelpCategory]?
+        public let coordinates: CDYelpCoordinates?
+        public let displayPhone: String?
+        public let hours: [CDYelpHour]?
+        public let id: String?
+        public let alias: String?
+        public let imageUrl: String?
+        public let isClaimed: Bool?
+        public let isClosed: Bool?
+        public let location: CDYelpLocation.Detailed?
+        public let messaging: CDYelpMessaging?
+        public let name: String?
+        public let phone: String?
+        public let photos: [String]?
+        public let price: String?
+        public let rating: Double?
+        public let reviewCount: Int?
+        public let url: String?
+        public let transactions: [String]?
+        public let specialHours: [CDYelpSpecialHour]?
+        public let attributes: [String: String]?
+
+        enum CodingKeys: String, CodingKey {
+            case categories
+            case coordinates
+            case displayPhone = "display_phone"
+            case hours
+            case id
+            case alias
+            case imageUrl = "image_url"
+            case isClaimed = "is_claimed"
+            case isClosed = "is_closed"
+            case location
+            case messaging
+            case name
+            case phone
+            case photos
+            case price
+            case rating
+            case reviewCount = "review_count"
+            case url
+            case transactions
+            case specialHours
+            case attributes
+        }
+
+        public func imageUrlAsUrl() -> URL? {
+            if let imageUrl = self.imageUrl,
+               let asUrl = URL(string: imageUrl) {
+                return asUrl
+            }
+            return nil
+        }
+
+        public func urlAsUrl() -> URL? {
+            if let url = self.url,
+               let asUrl = URL(string: url) {
+                return asUrl
+            }
+            return nil
+        }
+
+        public func photosAsUrls() -> [URL] {
+            var asUrls: [URL] = []
+            if let photos = self.photos {
+                for photo in photos {
+                    if let url = URL(string: photo) {
+                        asUrls.append(url)
+                    }
+                }
+            }
+            return asUrls
+        }
+    }
+
+    public struct BusinessMatch: Decodable {
+
+        public let id: String?
+        public let alias: String?
+        public let name: String?
+        public let location: CDYelpLocation.Detailed?
+        public let coordinates: CDYelpCoordinates?
+        public let phone: String?
+
+        enum CodingKeys: String, CodingKey {
+            case id
+            case alias
+            case name
+            case location
+            case coordinates
+            case phone
+        }
+    }
+
+    public struct Autocomplete: Decodable {
+
+        public let id: String?
+        public let name: String?
+
+        enum CodingKeys: String, CodingKey {
+            case id
+            case name
+        }
     }
 }

--- a/Source/CDYelpBusinessResponse.swift
+++ b/Source/CDYelpBusinessResponse.swift
@@ -27,11 +27,24 @@
 
 public struct CDYelpBusinessResponse: Decodable {
 
-    public let business: CDYelpBusiness?
+    public let business: CDYelpBusiness.Detailed?
     public let error: CDYelpError?
 
-    enum CodingKeys: String, CodingKey {
-        case business = ""
-        case error
+    public init(from decoder: Decoder) throws {
+        var decodedBusiness: CDYelpBusiness.Detailed?
+        do {
+            decodedBusiness = try CDYelpBusiness.Detailed(from: decoder)
+        } catch _ {
+            decodedBusiness = nil
+        }
+        var decodedError: CDYelpError?
+        do {
+            decodedError = try CDYelpError(from: decoder)
+        } catch _ {
+            decodedError = nil
+        }
+
+        business = decodedBusiness
+        error = decodedError
     }
 }

--- a/Source/CDYelpCategoriesResponse.swift
+++ b/Source/CDYelpCategoriesResponse.swift
@@ -27,9 +27,11 @@
 
 public struct CDYelpCategoriesResponse: Decodable {
 
-    public let categories: [CDYelpCategory]?
+    public let categories: [CDYelpCategory.Detailed]?
+    public let error: CDYelpError?
 
     enum CodingKeys: String, CodingKey {
         case categories
+        case error
     }
 }

--- a/Source/CDYelpCategory.swift
+++ b/Source/CDYelpCategory.swift
@@ -29,15 +29,25 @@ public struct CDYelpCategory: Decodable {
 
     public let alias: String?
     public let title: String?
-    public let parentAliases: [String]?
-    public let countryWhitelist: [String]?
-    public let countryBlacklist: [String]?
 
     enum CodingKeys: String, CodingKey {
         case alias
         case title
-        case parentAliases = "parent_aliases"
-        case countryWhitelist = "country_whitelist"
-        case countryBlacklist = "country_blacklist"
+    }
+
+    public struct Detailed: Decodable {
+        public let alias: String?
+        public let title: String?
+        public let parentAliases: [String]?
+        public let countryWhitelist: [String]?
+        public let countryBlacklist: [String]?
+
+        enum CodingKeys: String, CodingKey {
+            case alias
+            case title
+            case parentAliases = "parent_aliases"
+            case countryWhitelist = "country_whitelist"
+            case countryBlacklist = "country_blacklist"
+        }
     }
 }

--- a/Source/CDYelpCategoryResponse.swift
+++ b/Source/CDYelpCategoryResponse.swift
@@ -27,9 +27,11 @@
 
 public struct CDYelpCategoryResponse: Decodable {
 
-    public let category: CDYelpCategory?
+    public let category: CDYelpCategory.Detailed?
+    public let error: CDYelpError?
 
     enum CodingKeys: String, CodingKey {
         case category
+        case error
     }
 }

--- a/Source/CDYelpEnums.swift
+++ b/Source/CDYelpEnums.swift
@@ -36,7 +36,6 @@ public enum CDYelpAttributeFilter: String {
     case requestAQuote          = "request_a_quote"
     case reservation            = "reservation"
     case waitlistReservation    = "waitlist_reservation"
-    case cashback               = "cashback"
     case deals                  = "deals"
     case genderNeutralRestrooms = "gender_neutral_restrooms"
     case openToAll              = "open_to_all"
@@ -1731,8 +1730,6 @@ public enum CDYelpStarsSize: String {
 ///
 public enum CDYelpTransactionType: String {
     case foodDelivery           = "delivery"
-    case pickup                 = "pickup"
-    case restaurantReservation  = "restaurant_reservation"
 }
 
 // swiftlint:enable file_length

--- a/Source/CDYelpEvent.swift
+++ b/Source/CDYelpEvent.swift
@@ -38,9 +38,9 @@ public struct CDYelpEvent: Decodable {
     public let cost: Int?
     public let costMax: Double?
     public let description: String?
-    public let eventSiteUrl: URL?
+    public let eventSiteUrl: String?
     public let id: String?
-    public let imageUrl: URL?
+    public let imageUrl: String?
     public let interestedCount: Int?
     public let isCanceled: Bool?
     public let isFree: Bool?
@@ -51,7 +51,7 @@ public struct CDYelpEvent: Decodable {
     public let ticketsUrl: String?
     public let timeEnd: Date?
     public let timeStart: Date?
-    public let location: CDYelpLocation?
+    public let location: CDYelpLocation.Detailed?
     public let businessId: String?
 
     enum CodingKeys: String, CodingKey {
@@ -75,5 +75,21 @@ public struct CDYelpEvent: Decodable {
         case timeStart = "time_start"
         case location
         case businessId = "business_id"
+    }
+
+    public func eventSiteUrlAsUrl() -> URL? {
+        if let eventSiteUrl = self.eventSiteUrl,
+           let asUrl = URL(string: eventSiteUrl) {
+            return asUrl
+        }
+        return nil
+    }
+
+    public func imageUrlAsUrl() -> URL? {
+        if let imageUrl = self.imageUrl,
+           let asUrl = URL(string: imageUrl) {
+            return asUrl
+        }
+        return nil
     }
 }

--- a/Source/CDYelpEventResponse.swift
+++ b/Source/CDYelpEventResponse.swift
@@ -1,8 +1,8 @@
 //
-//  CDYelpFusionKit.swift
+//  CDYelpEventResponse.swift
 //  CDYelpFusionKit
 //
-//  Created by Christopher de Haan on 6/11/22.
+//  Created by Christopher de Haan on 7/4/22.
 //
 //  Copyright © 2016-2022 Christopher de Haan <contact@christopherdehaan.me>
 //
@@ -25,12 +25,26 @@
 //  THE SOFTWARE.
 //
 
-import Foundation
+public struct CDYelpEventResponse: Decodable {
 
-// Enforce minimum Swift version for all platforms and build systems.
-#if swift(<5.3)
-#error("CDYelpFusionKit doesn't support Swift versions below 5.3.")
-#endif
+    public let event: CDYelpEvent?
+    public let error: CDYelpError?
 
-/// Current CDYelpFusionKit version. Necessary since SPM doesn't use dynamic libraries. Plus this will be more accurate.
-let version = "3.2.0"
+    public init(from decoder: Decoder) throws {
+        var decodedEvent: CDYelpEvent?
+        do {
+            decodedEvent = try CDYelpEvent(from: decoder)
+        } catch _ {
+            decodedEvent = nil
+        }
+        var decodedError: CDYelpError?
+        do {
+            decodedError = try CDYelpError(from: decoder)
+        } catch _ {
+            decodedError = nil
+        }
+
+        event = decodedEvent
+        error = decodedError
+    }
+}

--- a/Source/CDYelpLocation.swift
+++ b/Source/CDYelpLocation.swift
@@ -34,8 +34,6 @@ public struct CDYelpLocation: Decodable {
     public let state: String?
     public let zipCode: String?
     public let country: String?
-    public let displayAddress: [String]?
-    public let crossStreets: String?
 
     enum CodingKeys: String, CodingKey {
         case addressOne = "address1"
@@ -45,7 +43,29 @@ public struct CDYelpLocation: Decodable {
         case state
         case zipCode = "zip_code"
         case country
-        case displayAddress = "display_address"
-        case crossStreets = "cross_streets"
+    }
+
+    public struct Detailed: Decodable {
+        public let addressOne: String?
+        public let addressTwo: String?
+        public let addressThree: String?
+        public let displayAddress: [String]?
+        public let crossStreets: String?
+        public let city: String?
+        public let state: String?
+        public let zipCode: String?
+        public let country: String?
+
+        enum CodingKeys: String, CodingKey {
+            case addressOne = "address1"
+            case addressTwo = "address2"
+            case addressThree = "address3"
+            case displayAddress = "display_address"
+            case crossStreets = "cross_streets"
+            case city
+            case state
+            case zipCode = "zip_code"
+            case country
+        }
     }
 }

--- a/Source/CDYelpMessaging.swift
+++ b/Source/CDYelpMessaging.swift
@@ -1,8 +1,8 @@
 //
-//  CDYelpFusionKit.swift
+//  CDYelpMessaging.swift
 //  CDYelpFusionKit
 //
-//  Created by Christopher de Haan on 6/11/22.
+//  Created by Christopher de Haan on 6/14/22.
 //
 //  Copyright © 2016-2022 Christopher de Haan <contact@christopherdehaan.me>
 //
@@ -25,12 +25,27 @@
 //  THE SOFTWARE.
 //
 
-import Foundation
-
-// Enforce minimum Swift version for all platforms and build systems.
-#if swift(<5.3)
-#error("CDYelpFusionKit doesn't support Swift versions below 5.3.")
+#if !os(OSX)
+    import UIKit
+#else
+    import Foundation
 #endif
 
-/// Current CDYelpFusionKit version. Necessary since SPM doesn't use dynamic libraries. Plus this will be more accurate.
-let version = "3.2.0"
+public struct CDYelpMessaging: Decodable {
+
+    public let url: String?
+    public let useCaseText: String?
+
+    enum CodingKeys: String, CodingKey {
+        case url
+        case useCaseText = "use_case_text"
+    }
+
+    public func urlAsUrl() -> URL? {
+        if let url = self.url,
+           let asUrl = URL(string: url) {
+            return asUrl
+        }
+        return nil
+    }
+}

--- a/Source/CDYelpReview.swift
+++ b/Source/CDYelpReview.swift
@@ -35,9 +35,9 @@ public struct CDYelpReview: Decodable {
 
     public let id: String?
     public let text: String?
-    public let url: URL?
+    public let url: String?
     public let rating: Int?
-    public let timeCreated: Date?
+    public let timeCreated: String?
     public let user: CDYelpUser?
 
     enum CodingKeys: String, CodingKey {
@@ -47,5 +47,21 @@ public struct CDYelpReview: Decodable {
         case rating
         case timeCreated = "time_created"
         case user
+    }
+
+    public func urlAsUrl() -> URL? {
+        if let url = self.url,
+           let asUrl = URL(string: url) {
+            return asUrl
+        }
+        return nil
+    }
+
+    public func timeCreatedAsDate() -> Date? {
+        if let timeCreated = self.timeCreated {
+            let formatter = DateFormatter()
+            return formatter.date(from: timeCreated)
+        }
+        return nil
     }
 }

--- a/Source/CDYelpSearchResponse.swift
+++ b/Source/CDYelpSearchResponse.swift
@@ -25,17 +25,58 @@
 //  THE SOFTWARE.
 //
 
-public struct CDYelpSearchResponse: Decodable {
+public struct CDYelpSearchResponse {
+    public struct Business: Decodable {
 
-    public let total: Int?
-    public let businesses: [CDYelpBusiness]?
-    public let region: CDYelpRegion?
-    public let error: CDYelpError?
+        public let total: Int?
+        public let businesses: [CDYelpBusiness.BusinessSearch]?
+        public let region: CDYelpRegion?
+        public let error: CDYelpError?
 
-    enum CodingKeys: String, CodingKey {
-        case total
-        case businesses
-        case region
-        case error
+        enum CodingKeys: String, CodingKey {
+            case total
+            case businesses
+            case region
+            case error
+        }
+    }
+
+    public struct Phone: Decodable {
+
+        public let total: Int?
+        public let businesses: [CDYelpBusiness.PhoneSearch]?
+        public let error: CDYelpError?
+
+        enum CodingKeys: String, CodingKey {
+            case total
+            case businesses
+            case error
+        }
+    }
+
+    public struct Transaction: Decodable {
+
+        public let total: Int?
+        public let businesses: [CDYelpBusiness.TransactionSearch]?
+        public let error: CDYelpError?
+
+        enum CodingKeys: String, CodingKey {
+            case total
+            case businesses
+            case error
+        }
+    }
+
+    public struct BusinessMatch: Decodable {
+
+        public let total: Int?
+        public let businesses: [CDYelpBusiness.BusinessMatch]?
+        public let error: CDYelpError?
+
+        enum CodingKeys: String, CodingKey {
+            case total
+            case businesses
+            case error
+        }
     }
 }

--- a/Source/CDYelpSpecialHour.swift
+++ b/Source/CDYelpSpecialHour.swift
@@ -1,8 +1,8 @@
 //
-//  CDYelpFusionKit.swift
+//  CDYelpSpecialHour.swift
 //  CDYelpFusionKit
 //
-//  Created by Christopher de Haan on 6/11/22.
+//  Created by Christopher de Haan on 6/14/22.
 //
 //  Copyright © 2016-2022 Christopher de Haan <contact@christopherdehaan.me>
 //
@@ -25,12 +25,33 @@
 //  THE SOFTWARE.
 //
 
-import Foundation
-
-// Enforce minimum Swift version for all platforms and build systems.
-#if swift(<5.3)
-#error("CDYelpFusionKit doesn't support Swift versions below 5.3.")
+#if !os(OSX)
+    import UIKit
+#else
+    import Foundation
 #endif
 
-/// Current CDYelpFusionKit version. Necessary since SPM doesn't use dynamic libraries. Plus this will be more accurate.
-let version = "3.2.0"
+public struct CDYelpSpecialHour: Decodable {
+
+    public let date: String?
+    public let isClosed: Bool?
+    public let start: String?
+    public let end: String?
+    public let isOvernight: Bool?
+
+    enum CodingKeys: String, CodingKey {
+        case date
+        case isClosed = "is_closed"
+        case start
+        case end
+        case isOvernight = "is_overnight"
+    }
+
+    public func dateAsDate() -> Date? {
+        if let date = self.date {
+            let formatter = DateFormatter()
+            return formatter.date(from: date)
+        }
+        return nil
+    }
+}

--- a/Source/CDYelpUser.swift
+++ b/Source/CDYelpUser.swift
@@ -34,14 +34,30 @@
 public struct CDYelpUser: Decodable {
 
     public let id: String?
-    public let profileUrl: URL?
+    public let profileUrl: String?
     public let name: String?
-    public let imageUrl: URL?
+    public let imageUrl: String?
 
     enum CodingKeys: String, CodingKey {
         case id
         case profileUrl = "profile_url"
         case name
         case imageUrl = "image_url"
+    }
+
+    public func profileUrlAsUrl() -> URL? {
+        if let profileUrl = self.profileUrl,
+           let asUrl = URL(string: profileUrl) {
+            return asUrl
+        }
+        return nil
+    }
+
+    public func imageUrlAsUrl() -> URL? {
+        if let imageUrl = self.imageUrl,
+           let asUrl = URL(string: imageUrl) {
+            return asUrl
+        }
+        return nil
     }
 }


### PR DESCRIPTION
### Goals :soccer:
- Create detailed struct objects so that API methods only return attributes that are supported by the endpoint
- Return dates and urls as strings while providing helper methods to convert to `Date` and `URL`

### Implementation Details :construction:
- `CDYelpBusiness.BusinessSearch`, `CDYelpBusiness.PhoneSearch`, `CDYelpBusiness.TransactionSearch`, `CDYelpBusiness.Detailed`, `CDYelpBusiness.BusinessMatch`, and `CDYelpBusiness.Autocomplete` structs
- `CDYelpCategory.Detailed` struct
- `CDYelpEventResponse` struct
- `CDYelpLocation.Detailed` struct
- `CDYelpMessaging` struct
- `CDYelpSearchResponse.Business`, `CDYelpSearchResponse.Phone`, `CDYelpSearchResponse.Transaction`, and `CDYelpSearchResponse.BusinessMatch` structs
- `CDYelpSpecialHour` struct
-`Date` types to `String`
- `URL` types to `String`
- `toDate` methods for `String` representations
- `toUrl` methods for `String` representations

### Testing Details 🔍
Tested locally